### PR TITLE
Fix break in path with spaces

### DIFF
--- a/scripts/mp/create-single-vm.sh
+++ b/scripts/mp/create-single-vm.sh
@@ -27,7 +27,7 @@ else
       --mem ${VM_MEM} \
       --disk ${VM_DISK} \
       --cpus ${VM_CPUS} \
-      --cloud-init ${CLOUD_INIT} \
+      --cloud-init "${CLOUD_INIT}" \
       ${VM_IMAGE}
   # Where "permanent data" will be stored
   info "MOUNTING HOST:${STORAGE_SRC} --> VM:${STORAGE_DST}"


### PR DESCRIPTION
This patch fixes the "Too many arguments supplied" error in the `multipass launch` command due to the missing quoting of the cloud-init file path.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>